### PR TITLE
Add "remove watermark" functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,32 @@ watermark = watermarker.get_watermark(watermarked_audio, sample_rate=sr)
 print(f"Extracted watermark: {watermark}")
 ```
 
+#### Removing a Watermark
+
+```python
+import perth
+import librosa
+
+# Load the watermarked audio
+watermarked_audio, sr = librosa.load("output.wav", sr=None)
+
+# Initialize watermarker (same as used for embedding)
+watermarker = perth.PerthImplicitWatermarker()
+
+# Remove watermark
+clean_audio = watermarker.remove_watermark(watermarked_audio, sample_rate=sr)
+print(f"Extracted watermark: {watermark}")
+
+# Save clean audio
+sf.write("clean.wav", clean_audio, sr)
+
+# Check detection fails
+watermark = watermarker.get_watermark(watermarked_audio, sample_rate=sr)
+print(f"Extracted watermark (input): {watermark}")
+watermark = watermarker.get_watermark(clean_audio, sample_rate=sr)
+print(f"Extracted watermark (output): {watermark}")
+```
+
 ### Perth Implicit Watermarker
 
 The Perth-Net Implicit watermarker uses a neural network-based approach for embedding and extracting watermarks. It's designed to be robust against various audio manipulations while maintaining high audio quality.

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ print(f"Extracted watermark: {watermark}")
 ```python
 import perth
 import librosa
+import soundfile as sf
 
 # Load the watermarked audio
 watermarked_audio, sr = librosa.load("output.wav", sr=None)
@@ -95,7 +96,6 @@ watermarker = perth.PerthImplicitWatermarker()
 
 # Remove watermark
 clean_audio = watermarker.remove_watermark(watermarked_audio, sample_rate=sr)
-print(f"Extracted watermark: {watermark}")
 
 # Save clean audio
 sf.write("clean.wav", clean_audio, sr)

--- a/perth/perth_net/perth_net_implicit/perth_watermarker.py
+++ b/perth/perth_net/perth_net_implicit/perth_watermarker.py
@@ -54,3 +54,54 @@ class PerthImplicitWatermarker(WatermarkerBase):
         wmark_pred = wmark_pred.clip(0., 1.)
         wmark_pred = wmark_pred.round() if round else wmark_pred
         return wmark_pred.detach().cpu().numpy()
+
+    def remove_watermark(self, wm_signal, sample_rate, round=True, method='fixed_point', steps=None, **_):
+        change_rate = sample_rate != self.perth_net.hp.sample_rate
+        if change_rate:
+            wm_signal = resample(wm_signal, orig_sr=sample_rate, target_sr=self.perth_net.hp.sample_rate,
+                                 res_type="polyphase")
+        wm_signal = _to_tensor(wm_signal, self.perth_net.device)
+        wm_magspec, phase = self.perth_net.ap.signal_to_magphase(wm_signal)
+        wm_magspec = wm_magspec.to(self.perth_net.device)
+
+        if method == 'fixed_point':
+            if steps is None:
+                # change to do more fixed-point iterations if needed, 1 seems enough
+                steps = 1
+            for i in range(steps):
+                # encode the watermark again to get direction
+                wm2_magspec, _mask = self.perth_net.encoder(wm_magspec[None])
+                wm2_magspec = wm2_magspec[0]
+                wmark_dir = wm2_magspec - wm_magspec
+
+                # run decoder to get amount
+                wmark_pred = self.perth_net.decoder(wm_magspec[None])[0]
+                wmark_pred = wmark_pred.clip(0., 1.)
+
+                # go the opposite direction
+                wm_magspec -= wmark_pred * wmark_dir
+        elif method == 'adversarial':
+            if steps is None:
+                # change to do more adversarial iterations if needed, 5 seems enough
+                steps = 5
+
+            wm_magspec_orig = wm_magspec.clone()
+            wm_magspec.requires_grad = True
+            
+            optimizer = torch.optim.Adam([ wm_magspec ], lr=1e-3)
+
+            for i in range(steps):
+                # XXX: could add augments here
+                # to make adversarial sample robust to new attacks
+
+                loss = self.perth_net.decoder(wm_magspec[None])[0]
+                
+                optimizer.zero_grad()
+                loss.backward()
+                optimizer.step()
+ 
+        # assemble back into unwatermarked signal
+        wm_signal = self.perth_net.ap.magphase_to_signal(wm_magspec, phase)
+        wm_signal = wm_signal.detach().cpu().numpy()
+        return resample(wm_signal, orig_sr=self.perth_net.hp.sample_rate, target_sr=sample_rate) if change_rate \
+            else wm_signal

--- a/perth/utils.py
+++ b/perth/utils.py
@@ -180,7 +180,11 @@ def calculate_audio_metrics(original: np.ndarray, watermarked: np.ndarray) -> Di
         - psnr: Peak Signal-to-Noise Ratio (dB)
     """
     if len(original) != len(watermarked):
-        raise ValueError("Original and watermarked audio must have the same length")
+        print(f"Original and watermarked audio don't have the same length {len(original)} != {len(watermarked)}")
+        min_len = min(len(original), len(watermarked))
+        original = original[:min_len]
+        watermarked = watermarked[:min_len]
+
     
     # Calculate Mean Squared Error
     mse = np.mean((original - watermarked) ** 2)


### PR DESCRIPTION
This pull request adds the option to remove the watermark from watermarked content.

Since both the watermarker and the detector are public and do not rely on any secret information, the added watermark is easily removed either:
- by rewatermarking the content and subtracting it from input to get a signal very close to the watermark signal; then subtracting it again to get back to original content.
- or by applying basic adversarial example forgery by computing the gradient of the detector response wrt the input content 

Just as Trustmark (https://github.com/adobe/trustmark) released a model to remove their watermark making it explicit that robustness to intentional removal is not provided by their solution, this pull request makes it clear that this is also the case for the Perth watermarking method.

Hoefully it will help avoiding a false sentiment of security from users of the model.