### PR TITLE
Replace deprecated pkg_resources with importlib.resources

### DIFF
--- a/perth/perth_net/__init__.py
+++ b/perth/perth_net/__init__.py
@@ -1,4 +1,3 @@
-from pkg_resources import resource_filename
-PREPACKAGED_MODELS_DIR = resource_filename(__name__, "pretrained")
-
+from importlib.resources import files
 from .perth_net_implicit.perth_watermarker import PerthImplicitWatermarker
+PREPACKAGED_MODELS_DIR = files(__name__).joinpath("pretrained")

--- a/perth/perth_net/__init__.py
+++ b/perth/perth_net/__init__.py
@@ -1,3 +1,4 @@
 from importlib.resources import files
-from .perth_net_implicit.perth_watermarker import PerthImplicitWatermarker
+
 PREPACKAGED_MODELS_DIR = files(__name__).joinpath("pretrained")
+from .perth_net_implicit.perth_watermarker import PerthImplicitWatermarker  # noqa: E402, F401


### PR DESCRIPTION
Fix deprecation warning by replacing `pkg_resources.resource_filename` with `importlib.resources.files()`, ensuring compatibility with future `setuptools` versions.
Python `< 3.10` is EOL as of October 2025, so this change safely replaces `pkg_resources` with the standard `importlib.resources`.
This PR fix #10 