### PR TITLE
chore: split dependencies to runtime + extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,6 @@ extra = [
     "pandas>=2.0.0",
     "praat-parselmouth>=0.4.2",
     "pyloudnorm>=0.1.1",
-    "pyrubberband>=0.4.0",
     "scikit-learn>=1.3.0",
     "sox>=1.4.1",
     "tabulate>=0.9.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "resemble-perth"
-version = "1.0.1"
+version = "1.1.0"
 description = "Audio Watermarking and Detection Library"
 license = { text = "MIT" }
 readme = { file = "README.md", content-type = "text/markdown" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,29 +32,35 @@ classifiers = [
 ]
 
 dependencies = [
-    "bitstring>=4.0.0",
-    "librosa>=0.11.0",
-    "matplotlib>=3.8.0",
-    "numpy>=1.24.0",
-    "pandas>=2.0.0",
-    "Pillow>=9.0.0",
-    "praat-parselmouth>=0.4.2",
-    "pydub>=0.25.1",
-    "pyloudnorm>=0.1.1",
-    "pyrubberband>=0.4.0",
-    "PyWavelets>=1.3.0",
     "PyYAML>=6.0",
-    "scikit-learn>=1.3.0",
+    "librosa>=0.11.0",
+    "numpy>=1.24.0",
+    "pydub>=0.25.1",
     "soundfile>=0.12.0",
-    "sox>=1.4.1",
-    "tabulate>=0.9.0",
-    "tensorboard>=2.14.0",
     "torch>=2.1.0",
     "torchaudio>=2.1.0",
-    "tqdm>=4.64.0",
 ]
 
 [dependency-groups]
+examples = [
+    "tqdm>=4.64.0",
+]
+
+extra = [
+    "Pillow>=9.0.0",
+    "PyWavelets>=1.3.0",
+    "bitstring>=4.0.0",
+    "matplotlib>=3.8.0",
+    "pandas>=2.0.0",
+    "praat-parselmouth>=0.4.2",
+    "pyloudnorm>=0.1.1",
+    "pyrubberband>=0.4.0",
+    "scikit-learn>=1.3.0",
+    "sox>=1.4.1",
+    "tabulate>=0.9.0",
+    "tensorboard>=2.14.0",
+]
+
 dev = [
     "pre-commit>=4.5.0",
     "ruff>=0.14.8",
@@ -67,7 +73,7 @@ Documentation = "https://github.com/resemble-ai/perth/blob/main/README.md"
 "Source Code" = "https://github.com/resemble-ai/perth"
 
 [tool.uv.build-backend]
-module-root = "src"      
+module-root = "src"
 module-name = "perth"
 
 [project.scripts]

--- a/src/perth/utils.py
+++ b/src/perth/utils.py
@@ -6,7 +6,6 @@ import os
 import numpy as np
 import librosa
 import soundfile as sf
-import matplotlib.pyplot as plt
 from typing import Tuple, Optional, Dict
 from math import sqrt
 from scipy.stats import mode
@@ -139,6 +138,8 @@ def plot_audio_comparison(
         sample_rate: Sample rate of the audio
         output_path: Path to save the plot. If None, plot is shown interactively.
     """
+    import matplotlib.pyplot as plt
+
     fig, axs = plt.subplots(3, 1, figsize=(10, 12))
 
     # Plot waveforms

--- a/src/perth/waveform.py
+++ b/src/perth/waveform.py
@@ -69,12 +69,6 @@ def save_wav(wav, file_or_path, sample_rate: int, subtype="PCM_16"):
     sf.write(file_or_path, wav, sample_rate, subtype=subtype, format="wav")
 
 
-def pitch_shift(wav, sample_rate, semitones):  # TODO: unused function?
-    import pyrubberband as pyrb
-
-    return pyrb.pitch_shift(wav, sample_rate, semitones)
-
-
 def convert_to_mp3(wav_path, sample_rate=22050):
     segment = AudioSegment.from_wav(wav_path)
     tmpfile = tempfile.SpooledTemporaryFile(suffix=".mp3")

--- a/src/perth/waveform.py
+++ b/src/perth/waveform.py
@@ -6,7 +6,6 @@ import warnings
 from pathlib import Path
 import librosa
 import numpy as np
-import pyrubberband as pyrb
 import soundfile as sf
 from audioread import NoBackendError
 from pydub import AudioSegment
@@ -70,7 +69,9 @@ def save_wav(wav, file_or_path, sample_rate: int, subtype="PCM_16"):
     sf.write(file_or_path, wav, sample_rate, subtype=subtype, format="wav")
 
 
-def pitch_shift(wav, sample_rate, semitones):
+def pitch_shift(wav, sample_rate, semitones):  # TODO: unused function?
+    import pyrubberband as pyrb
+
     return pyrb.pitch_shift(wav, sample_rate, semitones)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -2075,28 +2075,14 @@ name = "resemble-perth"
 version = "1.0.1"
 source = { editable = "." }
 dependencies = [
-    { name = "bitstring" },
     { name = "librosa" },
-    { name = "matplotlib" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "pandas" },
-    { name = "pillow" },
-    { name = "praat-parselmouth" },
     { name = "pydub" },
-    { name = "pyloudnorm" },
-    { name = "pyrubberband" },
-    { name = "pywavelets", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "pywavelets", version = "1.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pyyaml" },
-    { name = "scikit-learn" },
     { name = "soundfile" },
-    { name = "sox" },
-    { name = "tabulate" },
-    { name = "tensorboard" },
     { name = "torch" },
     { name = "torchaudio" },
-    { name = "tqdm" },
 ]
 
 [package.dev-dependencies]
@@ -2104,35 +2090,55 @@ dev = [
     { name = "pre-commit" },
     { name = "ruff" },
 ]
+examples = [
+    { name = "tqdm" },
+]
+extra = [
+    { name = "bitstring" },
+    { name = "matplotlib" },
+    { name = "pandas" },
+    { name = "pillow" },
+    { name = "praat-parselmouth" },
+    { name = "pyloudnorm" },
+    { name = "pyrubberband" },
+    { name = "pywavelets", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "pywavelets", version = "1.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scikit-learn" },
+    { name = "sox" },
+    { name = "tabulate" },
+    { name = "tensorboard" },
+]
 
 [package.metadata]
 requires-dist = [
-    { name = "bitstring", specifier = ">=4.0.0" },
     { name = "librosa", specifier = ">=0.11.0" },
-    { name = "matplotlib", specifier = ">=3.8.0" },
     { name = "numpy", specifier = ">=1.24.0" },
-    { name = "pandas", specifier = ">=2.0.0" },
-    { name = "pillow", specifier = ">=9.0.0" },
-    { name = "praat-parselmouth", specifier = ">=0.4.2" },
     { name = "pydub", specifier = ">=0.25.1" },
-    { name = "pyloudnorm", specifier = ">=0.1.1" },
-    { name = "pyrubberband", specifier = ">=0.4.0" },
-    { name = "pywavelets", specifier = ">=1.3.0" },
     { name = "pyyaml", specifier = ">=6.0" },
-    { name = "scikit-learn", specifier = ">=1.3.0" },
     { name = "soundfile", specifier = ">=0.12.0" },
-    { name = "sox", specifier = ">=1.4.1" },
-    { name = "tabulate", specifier = ">=0.9.0" },
-    { name = "tensorboard", specifier = ">=2.14.0" },
     { name = "torch", specifier = ">=2.1.0" },
     { name = "torchaudio", specifier = ">=2.1.0" },
-    { name = "tqdm", specifier = ">=4.64.0" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "pre-commit", specifier = ">=4.5.0" },
     { name = "ruff", specifier = ">=0.14.8" },
+]
+examples = [{ name = "tqdm", specifier = ">=4.64.0" }]
+extra = [
+    { name = "bitstring", specifier = ">=4.0.0" },
+    { name = "matplotlib", specifier = ">=3.8.0" },
+    { name = "pandas", specifier = ">=2.0.0" },
+    { name = "pillow", specifier = ">=9.0.0" },
+    { name = "praat-parselmouth", specifier = ">=0.4.2" },
+    { name = "pyloudnorm", specifier = ">=0.1.1" },
+    { name = "pyrubberband", specifier = ">=0.4.0" },
+    { name = "pywavelets", specifier = ">=1.3.0" },
+    { name = "scikit-learn", specifier = ">=1.3.0" },
+    { name = "sox", specifier = ">=1.4.1" },
+    { name = "tabulate", specifier = ">=0.9.0" },
+    { name = "tensorboard", specifier = ">=2.14.0" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1842,20 +1842,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyrubberband"
-version = "0.4.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "soundfile" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b4/5f/e4e737a216c9327931cdee8ca2194c916ee8a1748a8c7c80d5d5a8368d81/pyrubberband-0.4.0.tar.gz", hash = "sha256:74707ec8ca6c6234e84ad2d9a4aa5c08a62fcfd83da011d535d41f4388ac49f7", size = 6416, upload-time = "2024-09-30T17:53:00.796Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/88/238aa67e353012d8dd999372aedada3f627bc9895d5d2a5305e7ffb1affd/pyrubberband-0.4.0-py3-none-any.whl", hash = "sha256:0a803191f38debbbdfd9135939c1f75999e98511f19867d357b84e191f139ca9", size = 4798, upload-time = "2024-09-30T17:52:59.621Z" },
-]
-
-[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -2100,7 +2086,6 @@ extra = [
     { name = "pillow" },
     { name = "praat-parselmouth" },
     { name = "pyloudnorm" },
-    { name = "pyrubberband" },
     { name = "pywavelets", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "pywavelets", version = "1.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "scikit-learn" },
@@ -2133,7 +2118,6 @@ extra = [
     { name = "pillow", specifier = ">=9.0.0" },
     { name = "praat-parselmouth", specifier = ">=0.4.2" },
     { name = "pyloudnorm", specifier = ">=0.1.1" },
-    { name = "pyrubberband", specifier = ">=0.4.0" },
     { name = "pywavelets", specifier = ">=1.3.0" },
     { name = "scikit-learn", specifier = ">=1.3.0" },
     { name = "sox", specifier = ">=1.4.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -2058,7 +2058,7 @@ wheels = [
 
 [[package]]
 name = "resemble-perth"
-version = "1.0.1"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "librosa" },


### PR DESCRIPTION
This PR splits the dependencies for this package to those actually required at runtime (e.g. for https://github.com/resemble-ai/chatterbox) and to... well, others that aren't really required. I presume some of them are leftovers from training time.

I tested this by adding 

```yaml
[tool.uv.sources]
resemble-perth = { path = "../Perth" }
```
to my copy of Chatterbox, and inference still seems to work fine.

`uv run perth foo.wav` also works to watermark and verify a file.