### PR TITLE
Replace pkg_resources with importlib.resources

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "resemble-perth"
-version = "1.0.1"
+version = "1.0.2"
 description = "Audio Watermarking and Detection Library"
 license = { text = "MIT" }
 readme = { file = "README.md", content-type = "text/markdown" }

--- a/src/perth/__init__.py
+++ b/src/perth/__init__.py
@@ -26,5 +26,5 @@ if PerthImplicitWatermarker is not None:
     __all__.append("PerthImplicitWatermarker")
 
 # Version information
-__version__ = "1.0.0"
+__version__ = "1.0.2"
 __author__ = "Resemble AI Team"


### PR DESCRIPTION
## Summary

- Replace `pkg_resources` with `importlib.resources` in `perth_net/__init__.py`
- Bump version to 1.0.2

## Problem

`perth/perth_net/__init__.py` used `from pkg_resources import resource_filename`
to locate pretrained model files. `pkg_resources` comes from `setuptools`, which
removed it in v81+.

Since `perth/__init__.py` wraps the import chain in a bare
`try/except ImportError`, the failure is silently swallowed and
`PerthImplicitWatermarker` is set to `None`. Downstream, when chatterbox calls
`perth.PerthImplicitWatermarker()`, it raises `TypeError: 'NoneType' object is
not callable` with no indication of the root cause.

This particularly affects `uv`-managed environments, which don't install
setuptools by default.

## Fix

`importlib.resources` is part of the Python standard library (3.9+) and requires
no external dependency.

Fixes resemble-ai/chatterbox#390
Fixes resemble-ai/chatterbox#198
